### PR TITLE
Fixed issues with register call of ctxmenu addon failing.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.github.martinprause.cytoscape</groupId>
     <artifactId>cytoscape-addon</artifactId>
-    <version>0.0.9</version>
+    <version>0.0.10</version>
     <name>cytoscape-addon</name>
     <description>Integration of paper-slider for Vaadin platform</description>
     <url>https://github.com/martinprause/cytoscape-addon</url>

--- a/src/main/resources/META-INF/resources/frontend/cytoscape/cytoscape-element.js
+++ b/src/main/resources/META-INF/resources/frontend/cytoscape/cytoscape-element.js
@@ -54,8 +54,16 @@ class CytoscapeElement extends PolymerElement {
 
 	ready(){
 	    super.ready();
-		cytoscape.use( cxtmenu );
-		cytoscape.use( edgehandles ); 
+		try {
+			cytoscape.use( cxtmenu );
+		} catch (e) {
+
+		}
+		try {
+			cytoscape.use( edgehandles );
+		} catch (e) {
+
+		}
 		var mythis=this;
 
 		var mycy = cytoscape({


### PR DESCRIPTION
This fixes an issue when using the Addon throughout multiple views in the same vaadin session.

Without this fix the following error is thrown:
`Uncaught Error: Can not register `cxtmenu` for `core` since `cxtmenu` already exists in the prototype and can not be overridden
`

Since this basically means that the addon is already registered, it can safely be ignored.